### PR TITLE
Don't escape input to MandrillHtml's FromJSON.

### DIFF
--- a/mandrill.cabal
+++ b/mandrill.cabal
@@ -1,5 +1,5 @@
 name:                mandrill
-version:             0.1.1.0
+version:             0.2.0.0
 synopsis:            Library for interfacing with the Mandrill JSON API
 description:         Pure Haskell client for the Mandrill JSON API
 license:             MIT

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -135,7 +135,7 @@ instance ToJSON MandrillHtml where
   toJSON (MandrillHtml h) = String . TL.toStrict . Blaze.renderHtml $ h
 
 instance FromJSON MandrillHtml where
-  parseJSON (String h) = return $ MandrillHtml (Blaze.toHtml h)
+  parseJSON (String h) = return $ MandrillHtml (Blaze.preEscapedToHtml h)
   parseJSON v = typeMismatch "Expecting a String for MandrillHtml" v
 
 instance Arbitrary MandrillHtml where


### PR DESCRIPTION
This is so that round tripping MandrillHtml to and from JSON doesn't
change its value.
