### PR TITLE
Basic support for messages/send-template

### DIFF
--- a/src/Network/API/Mandrill.hs
+++ b/src/Network/API/Mandrill.hs
@@ -12,6 +12,7 @@ module Network.API.Mandrill (
   , emptyMessage
   , newTextMessage
   , newHtmlMessage
+  , newTemplateMessage
   , liftIO
 
   -- * Appendix: Example Usage
@@ -106,6 +107,16 @@ newHtmlMessage :: EmailAddress
 newHtmlMessage f t subj html = let body = mkMandrillHtml html in
   ((mmsg_html .~ body) . (mmsg_subject .~ subj)) $ (emptyMessage f t)
 
+--------------------------------------------------------------------------------
+-- | Create a new template message (no HTML).
+newTemplateMessage :: EmailAddress
+                   -- ^ Sender email
+                   -> [EmailAddress]
+                   -- ^ Receivers email
+                   -> T.Text
+                   -- ^ Subject
+                   -> MandrillMessage
+newTemplateMessage f t subj = (mmsg_subject .~ subj) $ (emptyMessage f t)
 
 --------------------------------------------------------------------------------
 -- | Create a new textual message. By default Mandrill doesn't require you

--- a/src/Network/API/Mandrill/Messages.hs
+++ b/src/Network/API/Mandrill/Messages.hs
@@ -24,3 +24,22 @@ send :: MandrillKey
      -> Maybe Manager
      -> IO (MandrillResponse [MessagesResponse])
 send k msg async ip_pool send_at = toMandrillResponse MessagesSend (MessagesSendRq k msg async ip_pool send_at)
+
+-- | Send a new transactional message through Mandrill using a template
+sendTemplate :: MandrillKey
+             -- ^ The API key
+             -> MandrillTemplate
+             -- ^ The template name
+             -> [MandrillTemplateContent]
+             -- ^ Template content for 'editable regions'
+             -> MandrillMessage
+             -- ^ The email message
+             -> Maybe Bool
+             -- ^ Enable a background sending mode that is optimized for bulk sending
+             -> Maybe T.Text
+             -- ^ ip_pool
+             -> Maybe UTCTime
+             -- ^ send_at
+             -> Maybe Manager
+             -> IO (MandrillResponse [MessagesResponse])
+sendTemplate k template content msg async ip_pool send_at = toMandrillResponse MessagesSendTemplate (MessagesSendTemplateRq k template content msg async ip_pool send_at)

--- a/src/Network/API/Mandrill/Messages/Types.hs
+++ b/src/Network/API/Mandrill/Messages/Types.hs
@@ -27,6 +27,19 @@ data MessagesSendRq = MessagesSendRq {
 makeLenses ''MessagesSendRq
 deriveJSON defaultOptions { fieldLabelModifier = drop 6 } ''MessagesSendRq
 
+--------------------------------------------------------------------------------
+data MessagesSendTemplateRq = MessagesSendTemplateRq {
+    _mstrq_key              :: MandrillKey
+  , _mstrq_template_name    :: T.Text
+  , _mstrq_template_content :: [MandrillTemplateContent]
+  , _mstrq_message          :: MandrillMessage
+  , _mstrq_async            :: Maybe Bool
+  , _mstrq_ip_pool          :: Maybe T.Text
+  , _mstrq_send_at          :: Maybe UTCTime
+  } deriving Show
+
+makeLenses ''MessagesSendTemplateRq
+deriveJSON defaultOptions { fieldLabelModifier = drop 7 } ''MessagesSendTemplateRq
 
 --------------------------------------------------------------------------------
 data MessagesResponse = MessagesResponse {

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -337,8 +337,8 @@ data MandrillTemplateContent = MandrillTemplateContent {
   , _mtc_content :: T.Text
   } deriving Show
 
-makeLenses ''MandrilTemplateContent
-deriveJSON defaultOptions { fieldLabelModifier = drop 5 } ''MandrilTemplateContent
+makeLenses ''MandrillTemplateContent
+deriveJSON defaultOptions { fieldLabelModifier = drop 5 } ''MandrillTemplateContent
 
 --------------------------------------------------------------------------------
 type MandrillKey = T.Text

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -331,7 +331,18 @@ instance Arbitrary MandrillMessage where
                               <*> pure []
 
 --------------------------------------------------------------------------------
+-- | Key value pair for replacing content in templates via 'Editable Regions'
+data MandrillTemplateContent = MandrillTemplateContent {
+    _mtc_name    :: T.Text
+  , _mtc_content :: T.Text
+  } deriving Show
+
+makeLenses ''MandrilTemplateContent
+deriveJSON defaultOptions { fieldLabelModifier = drop 5 } ''MandrilTemplateContent
+
+--------------------------------------------------------------------------------
 type MandrillKey = T.Text
+type MandrillTemplate = T.Text
 
 newtype MandrillDate = MandrillDate {
   fromMandrillDate :: UTCTime


### PR DESCRIPTION
I didn't add an online test since it will always fail if the template doesn't exist.
(Could probably combine this with the add/delete template api endpoints)

Let me know if there's anything you'd like me to change