### PR TITLE
Modify `Base64ByteString` type to support already-encoded payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 This module implement a low-level, 1:1 mapping API to
 the [Mandrill](http://mandrillapp.com) transactional email service.
 
+# Changelog
+
+## Version 0.4.0.0
+
+* Modified the `Base64ByteString` type to accept another constructor. This
+  allows the user to pass already-encoded Base64 strings which might be coming
+  upstream.
+
 # Example
 
 This package was built with pragmatism and reuse in mind. This means

--- a/mandrill.cabal
+++ b/mandrill.cabal
@@ -1,5 +1,5 @@
 name:                mandrill
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Library for interfacing with the Mandrill JSON API
 description:         Pure Haskell client for the Mandrill JSON API
 license:             MIT


### PR DESCRIPTION
This patch allows the user to pass his own already-encoded B64
bytestrings to be used as attachments.