### PR TITLE
MandrillResponse instances

### DIFF
--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DeriveFunctor       #-}
+{-# LANGUAGE DeriveFoldable      #-}
+{-# LANGUAGE DeriveTraversable   #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -45,7 +48,7 @@ data MandrillError = MandrillError {
   , _merr_code    :: !Int
   , _merr_name    :: !T.Text
   , _merr_message :: !T.Text
-  } deriving Show
+  } deriving (Show, Eq)
 
 makeLenses ''MandrillError
 deriveJSON defaultOptions { fieldLabelModifier = drop 6 } ''MandrillError
@@ -83,7 +86,7 @@ deriveJSON defaultOptions {
 -- which can be either a success or a failure.
 data MandrillResponse k =
     MandrillSuccess k
-  | MandrillFailure MandrillError deriving Show
+  | MandrillFailure MandrillError deriving (Show, Eq, Functor, Foldable, Traversable)
 
 instance FromJSON k => FromJSON (MandrillResponse k) where
   parseJSON v = case (parseMaybe parseJSON v) :: Maybe k of

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -26,6 +26,10 @@ import           Data.Aeson.TH
 import           Data.Aeson.Types
 import qualified Data.ByteString               as B
 import qualified Data.ByteString.Base64        as Base64
+#if !MIN_VERSION_base(4,8,0)
+import           Data.Foldable
+import           Data.Traversable
+#endif
 import qualified Data.HashMap.Strict           as H
 import           Data.Monoid
 import qualified Data.Text                     as T


### PR DESCRIPTION
I found myself defining `Functor`/`Traversable` instances for `MandrillResponse k`. It'll be much better if this instances won't be orphans and will belong to the library.

Good job with the library!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adinapoli/mandrill/32)
<!-- Reviewable:end -->
