### PR TITLE
fix inadvertent implementation of Aeson classes for EmailAddress

### DIFF
--- a/src/Network/API/Mandrill/Senders.hs
+++ b/src/Network/API/Mandrill/Senders.hs
@@ -27,7 +27,7 @@ data VerifyDomainResponse =
   VerifyDomainResponse
   { _vdres_status :: Text
   , _vdres_domain :: Text
-  , _vdres_email  :: TEV.EmailAddress
+  , _vdres_email  :: MandrillEmail
   } deriving Show
 
 makeLenses ''VerifyDomainResponse
@@ -42,4 +42,4 @@ verifyDomain :: MandrillKey
                 -> IO (MandrillResponse VerifyDomainResponse)
 verifyDomain k email =
   toMandrillResponse VerifyDomain
-  (VerifyDomainRq k (decodeUtf8 $ TEV.domainPart email) (decodeUtf8 $ TEV.localPart email))
+  (VerifyDomainRq k  (decodeUtf8 $ TEV.domainPart email) (decodeUtf8 $ TEV.localPart email))

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -387,13 +387,3 @@ instance FromJSON MandrillDate where
       case timeParse defaultTimeLocale "%Y-%m-%d %I:%M:%S%Q" (T.unpack t) of
         Just d -> pure $ MandrillDate d
         _      -> fail "could not parse Mandrill date"
-
-
-instance ToJSON TEV.EmailAddress where
-  toJSON = String . TL.decodeUtf8 . TEV.toByteString
-
-instance FromJSON TEV.EmailAddress where
-  parseJSON (String s) = case TEV.emailAddress (TL.encodeUtf8 s) of
-    Nothing -> mzero
-    Just x -> return x
-  parseJSON _ = mzero


### PR DESCRIPTION
I inadvertently implemented a ToJSON/FromJSON pair for a bare TEV.EmailAddress.

This is obviously a bad idea in a library - this patch reverts that and changes the verifyDomain call to use your MandrillEmail newtype.