### PR TITLE
Don't use microlens operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ the [Mandrill](http://mandrillapp.com) transactional email service.
 
 # Changelog
 
+## Version 0.5.3.5
+
+* Replaced dependency on lens with microlens (Courtesy of @tom-bop)
+
 ## Version 0.5.3.3
 
 * Relaxed upper bound on Aeson (see: fpco/stackage/issues/3337)

--- a/mandrill.cabal
+++ b/mandrill.cabal
@@ -1,5 +1,5 @@
 name:                mandrill
-version:             0.5.3.3
+version:             0.5.3.4
 synopsis:            Library for interfacing with the Mandrill JSON API
 description:         Pure Haskell client for the Mandrill JSON API
 license:             MIT
@@ -42,7 +42,8 @@ library
     , http-client >= 0.3.0
     , http-client-tls >= 0.2.0.0
     , aeson >= 0.7.0.3 && < 1.4.0.0
-    , lens >= 4.0
+    , microlens >= 0.4.0.1
+    , microlens-th >= 0.4.0.0
     , blaze-html >= 0.5.0.0
     , QuickCheck >= 2.6 && < 3.0
     , mtl < 3.0

--- a/mandrill.cabal
+++ b/mandrill.cabal
@@ -42,7 +42,6 @@ library
     , http-client >= 0.3.0
     , http-client-tls >= 0.2.0.0
     , aeson >= 0.7.0.3 && < 1.4.0.0
-    , microlens >= 0.4.0.1
     , microlens-th >= 0.4.0.0
     , blaze-html >= 0.5.0.0
     , QuickCheck >= 2.6 && < 3.0

--- a/src/Network/API/Mandrill.hs
+++ b/src/Network/API/Mandrill.hs
@@ -20,13 +20,13 @@ module Network.API.Mandrill (
   -- $exampleusage
   ) where
 
-import           Control.Lens
 import           Control.Monad.Reader
 import qualified Data.Aeson                          as JSON
 import qualified Data.HashMap.Strict                 as H
 import           Data.Monoid
 import qualified Data.Text                           as T
 import           Data.Time
+import           Lens.Micro
 import           Network.API.Mandrill.Messages       as M
 import           Network.API.Mandrill.Messages.Types as M
 import           Network.API.Mandrill.Trans          as M

--- a/src/Network/API/Mandrill.hs
+++ b/src/Network/API/Mandrill.hs
@@ -26,7 +26,6 @@ import qualified Data.HashMap.Strict                 as H
 import           Data.Monoid
 import qualified Data.Text                           as T
 import           Data.Time
-import           Lens.Micro
 import           Network.API.Mandrill.Messages       as M
 import           Network.API.Mandrill.Messages.Types as M
 import           Network.API.Mandrill.Trans          as M
@@ -107,7 +106,7 @@ newHtmlMessage :: EmailAddress
                -- ^ The HTML body
                -> MandrillMessage
 newHtmlMessage f t subj html = let body = mkMandrillHtml html in
-  ((mmsg_html .~ body) . (mmsg_subject .~ subj)) $ (emptyMessage f t)
+  (emptyMessage f t) { _mmsg_html = body, _mmsg_subject = subj }
 
 --------------------------------------------------------------------------------
 -- | Create a new template message (no HTML).
@@ -118,7 +117,7 @@ newTemplateMessage :: EmailAddress
                    -> T.Text
                    -- ^ Subject
                    -> MandrillMessage
-newTemplateMessage f t subj = (mmsg_subject .~ subj) $ (emptyMessage f t)
+newTemplateMessage f t subj = (emptyMessage f t) { _mmsg_subject = subj }
 
 --------------------------------------------------------------------------------
 -- | Create a new textual message. By default Mandrill doesn't require you
@@ -134,9 +133,11 @@ newTextMessage :: EmailAddress
                -- ^ The body, as normal text.
                -> MandrillMessage
 newTextMessage f t subj txt = let body = unsafeMkMandrillHtml txt in
-  ((mmsg_html .~ body) .
-   (mmsg_text .~ Just txt) .
-   (mmsg_subject .~ subj)) (emptyMessage f t)
+  (emptyMessage f t) {
+       _mmsg_html = body
+     , _mmsg_text = Just txt
+     , _mmsg_subject = subj
+     }
 
 
 --------------------------------------------------------------------------------

--- a/src/Network/API/Mandrill/Inbound.hs
+++ b/src/Network/API/Mandrill/Inbound.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Network.API.Mandrill.Inbound where
-import           Control.Lens
 import           Data.Aeson                    (FromJSON, ToJSON, parseJSON,
                                                 toJSON)
 import           Data.Aeson.TH                 (defaultOptions, deriveJSON)
 import           Data.Aeson.Types              (fieldLabelModifier)
 import           Data.Text                     (Text)
+import           Lens.Micro.TH                 (makeLenses)
 import           Network.API.Mandrill.HTTP     (toMandrillResponse)
 import           Network.API.Mandrill.Settings
 import           Network.API.Mandrill.Types

--- a/src/Network/API/Mandrill/Messages/Types.hs
+++ b/src/Network/API/Mandrill/Messages/Types.hs
@@ -5,12 +5,12 @@ module Network.API.Mandrill.Messages.Types where
 import           Data.Char
 import           Data.Time
 import qualified Data.Text as T
-import           Control.Lens
 import           Control.Monad
 import           Data.Monoid
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Aeson.TH
+import           Lens.Micro.TH (makeLenses)
 
 import           Network.API.Mandrill.Types
 

--- a/src/Network/API/Mandrill/Senders.hs
+++ b/src/Network/API/Mandrill/Senders.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Network.API.Mandrill.Senders where
-import           Control.Lens
 import           Data.Aeson                    (FromJSON, ToJSON, parseJSON,
                                                 toJSON)
 import           Data.Aeson.TH                 (defaultOptions, deriveJSON)
 import           Data.Aeson.Types              (Value (..), fieldLabelModifier)
 import           Data.Text                     (Text)
 import           Data.Text.Encoding            (decodeUtf8, encodeUtf8)
+import           Lens.Micro.TH                 (makeLenses)
 import           Network.API.Mandrill.HTTP     (toMandrillResponse)
 import           Network.API.Mandrill.Settings
 import           Network.API.Mandrill.Types

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -13,6 +13,7 @@ import           Control.Monad                 (mzero)
 import           Data.Char
 import           Data.Maybe
 import           Data.Time
+import           Lens.Micro.TH (makeLenses)
 import           Network.API.Mandrill.Utils
 import           Test.QuickCheck
 import           Text.Email.Validate
@@ -21,7 +22,6 @@ import           Data.Time.Format              (TimeLocale, defaultTimeLocale)
 #else
 import           System.Locale                 (TimeLocale, defaultTimeLocale)
 #endif
-import           Control.Lens
 import           Data.Aeson
 import           Data.Aeson.TH
 import           Data.Aeson.Types

--- a/src/Network/API/Mandrill/Users/Types.hs
+++ b/src/Network/API/Mandrill/Users/Types.hs
@@ -5,12 +5,12 @@ module Network.API.Mandrill.Users.Types where
 import           Data.Char
 import           Data.Time
 import qualified Data.Text as T
-import           Control.Lens
 import           Control.Monad
 import           Data.Monoid
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Aeson.TH
+import           Lens.Micro.TH (makeLenses)
 
 import           Network.API.Mandrill.Types
 

--- a/src/Network/API/Mandrill/Webhooks.hs
+++ b/src/Network/API/Mandrill/Webhooks.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE TemplateHaskell   #-}
 module Network.API.Mandrill.Webhooks where
 import           Control.Applicative           (pure)
-import           Control.Lens
 import           Control.Monad                 (mzero)
 import           Data.Aeson                    (FromJSON, ToJSON, parseJSON,
                                                 toJSON)
@@ -12,6 +11,7 @@ import           Data.Aeson.Types              (fieldLabelModifier)
 import           Data.Set                      (Set)
 import           Data.Text                     (Text)
 import qualified Data.Text                     as T
+import           Lens.Micro.TH                 (makeLenses)
 import           Network.API.Mandrill.HTTP     (toMandrillResponse)
 import           Network.API.Mandrill.Settings
 import           Network.API.Mandrill.Types


### PR DESCRIPTION
This builds on top of https://github.com/adinapoli/mandrill/pull/49 -- while https://github.com/adinapoli/mandrill/pull/49 simply changes what's imported, this PR removes the (very few) uses of lens operators.

This way, the only lens construct we use is `makeLenses` from `Lens.Micro.TH` - so that users of this library still have the lenses they had before if they want them.