### PR TITLE
Add `newTemplateMessage'`, set sender address and subject optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module implement a low-level, 1:1 mapping API to
 the [Mandrill](http://mandrillapp.com) transactional email service.
 
 # Changelog
-## Version 0.5.3.6
+## Version 0.5.4.0
 
 * Add `newTemplateMessage'` for sending message that uses a template whose sender address and subject are already configured in the Mandrill server.
 * Set `mmsg_subject` and `mmsg_from_email` optional.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This module implement a low-level, 1:1 mapping API to
 the [Mandrill](http://mandrillapp.com) transactional email service.
 
 # Changelog
+## Version 0.5.3.6
+
+* Add `newTemplateMessage'` for sending message that uses a template whose sender address and subject are already configured in the Mandrill server.
+* Set `mmsg_subject` and `mmsg_from_email` optional.
 
 ## Version 0.5.3.6
 

--- a/mandrill.cabal
+++ b/mandrill.cabal
@@ -1,5 +1,5 @@
 name:                mandrill
-version:             0.5.3.6
+version:             0.5.4.0
 synopsis:            Library for interfacing with the Mandrill JSON API
 description:         Pure Haskell client for the Mandrill JSON API
 license:             MIT

--- a/src/Network/API/Mandrill.hs
+++ b/src/Network/API/Mandrill.hs
@@ -125,7 +125,7 @@ newTemplateMessage f t subj = (emptyMessage (Just f) t) { _mmsg_subject = Just s
 -- This function is preferred when the template being used has the sender 
 -- address and subject already configured in the Mandrill server.
 newTemplateMessage' :: [EmailAddress]
-                    -- ^ Sender email
+                    -- ^ Receivers email
                     -> MandrillMessage
 newTemplateMessage' = emptyMessage Nothing
 

--- a/src/Network/API/Mandrill/HTTP.hs
+++ b/src/Network/API/Mandrill/HTTP.hs
@@ -18,7 +18,7 @@ toMandrillResponse :: (MandrillEndpoint ep, FromJSON a, ToJSON rq)
                    -> IO (MandrillResponse a)
 toMandrillResponse ep rq mbMgr = do
   let fullUrl = mandrillUrl <> toUrl ep
-  rq' <- parseUrl (T.unpack fullUrl)
+  rq' <- parseRequest (T.unpack fullUrl)
   let headers = [(hContentType, "application/json")]
   let jsonBody = encode rq
   let req = rq' {

--- a/src/Network/API/Mandrill/Types.hs
+++ b/src/Network/API/Mandrill/Types.hs
@@ -252,9 +252,9 @@ data MandrillMessage = MandrillMessage {
    -- ^ The full HTML content to be sent
  , _mmsg_text                      :: Maybe T.Text
    -- ^ Optional full text content to be sent
- , _mmsg_subject                   :: !T.Text
+ , _mmsg_subject                   :: !(Maybe T.Text)
    -- ^ The message subject
- , _mmsg_from_email                :: MandrillEmail
+ , _mmsg_from_email                :: Maybe MandrillEmail
    -- ^ The sender email address
  , _mmsg_from_name                 :: Maybe T.Text
    -- ^ Optional from name to be used
@@ -336,8 +336,8 @@ deriveJSON defaultOptions { fieldLabelModifier = drop 6 } ''MandrillMessage
 instance Arbitrary MandrillMessage where
   arbitrary = MandrillMessage <$> arbitrary
                               <*> pure Nothing
-                              <*> pure "Test Subject"
-                              <*> pure (MandrillEmail . fromJust $ emailAddress "sender@example.com")
+                              <*> pure (Just "Test Subject")
+                              <*> pure (MandrillEmail <$> emailAddress "sender@example.com")
                               <*> pure Nothing
                               <*> resize 2 arbitrary
                               <*> pure H.empty


### PR DESCRIPTION
According to https://mandrillapp.com/api/docs/templates.JSON.html#method=info, a template is allowed to have `from_email` and `subject` configured in the Mandrill server.  Therefore these 2 parameters can be omitted when sending a message with a template.